### PR TITLE
Updates for latest Zig

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -281,7 +281,7 @@ pub fn VM(
             }
 
             std.debug.assert(vm.stack.items(.loc).len == 1);
-            const result = vm.stack.pop();
+            const result = vm.stack.pop().?;
             std.debug.assert(result.value != .err);
             vm.reset();
             log.debug("returning = '{any}'", .{result});


### PR DESCRIPTION
Pop now returns an optional, caller must unwrap. One test fails I'm not sure if it's related--worth checking.